### PR TITLE
Aborting when the script can not verify the python3-azuremetadata version

### DIFF
--- a/sc-repocheck.py
+++ b/sc-repocheck.py
@@ -2696,7 +2696,9 @@ def supported_metadata_version():
         ver = subprocess.check_output(
             ['rpm', '-q', 'python3-azuremetadata', '--queryformat', '%{VERSION}']).decode("utf-8")
     except subprocess.CalledProcessError:
-        ver = 0
+        logging.error("Could not verify the python3-azuremetadata version, Cannot continue")
+        sys.exit()
+
     # metadata version does not meet requirements to us --api latest
     if (ver > required_version) - (ver < required_version) == -1:
         return False

--- a/sc-repocheck.py
+++ b/sc-repocheck.py
@@ -2696,7 +2696,7 @@ def supported_metadata_version():
         ver = subprocess.check_output(
             ['rpm', '-q', 'python3-azuremetadata', '--queryformat', '%{VERSION}']).decode("utf-8")
     except subprocess.CalledProcessError:
-        logging.error("Could not verify the python3-azuremetadata version, Cannot continue")
+        logging.error("Could not verify the python3-azuremetadata rpm version, Cannot continue")
         sys.exit()
 
     # metadata version does not meet requirements to us --api latest


### PR DESCRIPTION
The current process assigns a value of 0 (integer) to the "version" variable then compares that value to a expected string values, the script aborts without logging the issue or printing a meaningful message to non-python developers.