### PR TITLE
fix for token referenced before assignment

### DIFF
--- a/sc-repocheck.py
+++ b/sc-repocheck.py
@@ -2842,9 +2842,9 @@ def check_metadata(framework, args):
             method='PUT')
         try:
             token = urllib.request.urlopen(request).read().decode()
+            request_header = {'X-aws-ec2-metadata-token': token}
         except urllib.error.URLError:
             request_header = {}
-        request_header = {'X-aws-ec2-metadata-token': token}
         try:
             r = requests.get(instance_endpoint,
                              headers=request_header, timeout=5)


### PR DESCRIPTION
Fix to resolve the following error,

```
Traceback (most recent call last):
  File "sc-repocheck.py”, line 3383, in <module>
    main(args)
File "sc-repocheck.py”, line 3220, in main
    region = check_metadata(framework, args)
FILE "sc-repocheck.py”, line 2847, in check_metadata
    request_header = {‘X-aws-ec2-metadata-token’: token}
UnboundLocalError: local variable ‘token’ referenced before assignment
```